### PR TITLE
Update compile.js

### DIFF
--- a/src/instance/compile.js
+++ b/src/instance/compile.js
@@ -85,6 +85,10 @@ exports._compileNode = function (node) {
             break;
         // node
         case 3 :
+            //如果是空白节点则不做处理
+            if(/^\s+$/.test(node.nodeValue)){
+               return;
+            }
             this._compileTextNode(node);
             break;
         default:


### PR DESCRIPTION
如果是空白文本内容，如：

```
<div>
</div>
```

这样，那么不需要做一次parseText
